### PR TITLE
fixes client configuration if no yet exists ceph.conf

### DIFF
--- a/ceph/client.sls
+++ b/ceph/client.sls
@@ -5,9 +5,25 @@ ceph_client_packages:
   pkg.installed:
   - names: {{ client.pkgs }}
 
+/etc/ceph:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+
 {%- for keyring_name, keyring in client.keyring.iteritems() %}
 
 /etc/ceph/ceph.client.{{ keyring_name }}.keyring:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+    - replace: False
+    # bug, if file is empty no section is added by options_present
+    - contents: |
+        [client.{{ keyring_name  }}]
+
   ini.options_present:
   - sections:
       client.{{ keyring_name }}: {{ keyring|yaml }}
@@ -26,6 +42,15 @@ client.{{ keyring_name }}:
 {%- endfor %}
 
 /etc/ceph/ceph.conf:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+    - replace: False
+    # bug, if file is empty no section is added by options_present
+    - contents: |
+        [global]
+
   ini.options_present:
   - sections: {{ config|yaml }}
   - require:

--- a/ceph/client.sls
+++ b/ceph/client.sls
@@ -23,6 +23,8 @@ ceph_client_packages:
     # bug, if file is empty no section is added by options_present
     - contents: |
         [client.{{ keyring_name  }}]
+    - require:
+      - file: /etc/ceph
 
   ini.options_present:
   - sections:
@@ -50,10 +52,13 @@ client.{{ keyring_name }}:
     # bug, if file is empty no section is added by options_present
     - contents: |
         [global]
+    - require:
+      - file: /etc/ceph
 
   ini.options_present:
   - sections: {{ config|yaml }}
   - require:
     - pkg: ceph_client_packages
+    - file: /etc/ceph
 
 {%- endif %}


### PR DESCRIPTION
required is to create a file fit a [genera] section, otherwise not recognized as ini file. Similary the keyring files.