### PR TITLE
Update formula to support multiple ceph cluster in salt master

### DIFF
--- a/_grains/ceph.py
+++ b/_grains/ceph.py
@@ -19,6 +19,13 @@ def main():
                 break
         conf_file = conf_dir + cluster_name + '.conf'
 
+        # get the fsid from config file, for salt-formulas to filter on in case of multiple ceph clusters
+        with open(conf_file, 'r') as conf_fh:
+            for line in conf_fh.read().splitlines():
+                if 'fsid' in line:
+                    attr = shlex.split(line)
+                    grain['ceph']['fsid'] = attr[2]
+
         # osd
         if os.path.exists('/var/lib/ceph/osd'):
             mount_path = check_output("df -h | awk '{print $6}' | grep ceph | grep -v lockbox | sed 's/-[0-9]*//g' | awk 'NR==1{print $1}'", shell=True).rstrip()

--- a/ceph/common.sls
+++ b/ceph/common.sls
@@ -49,7 +49,7 @@ ceph_create_keyring_admin:
 
 {%- for node_name, node_grains in salt['mine.get']('ceph:common:keyring:admin', 'grains.items', 'pillar').iteritems() %}
 
-{%- if node_grains.ceph is defined and node_grains.ceph.ceph_keyring is defined and node_grains.ceph.ceph_keyring.admin is defined %}
+{%- if node_grains.ceph is defined and node_grains.ceph.ceph_keyring is defined and node_grains.ceph.ceph_keyring.admin is defined and node_grains.ceph.get('fsid', '') == common.fsid %}
 
 {%- if loop.index0 == 0 %}
 

--- a/ceph/files/crushmap
+++ b/ceph/files/crushmap
@@ -1,4 +1,4 @@
-{%- from "ceph/map.jinja" import setup with context -%}
+{%- from "ceph/map.jinja" import common, setup with context -%}
 # begin crush map
 
 {%- set types = {} -%}
@@ -7,7 +7,7 @@
 {%- set weights = {} -%}
 
 {%- for node_name, node_grains in salt['mine.get']('*', 'grains.items').iteritems() -%}
-  {%- if node_grains.get('ceph', {}).get('ceph_disk') -%}
+  {%- if node_grains.get('ceph', {}).get('ceph_disk') and node_grains.get('ceph', {}).get('fsid', '') == common.fsid -%}
     {# load OSDs and compute weight#}
     {%- set node_weight = [] -%}
     {%- for osd_id, osd in node_grains.ceph.ceph_disk.iteritems() -%}

--- a/ceph/files/mon_keyring
+++ b/ceph/files/mon_keyring
@@ -1,6 +1,7 @@
+{%- from "ceph/map.jinja" import common with context -%}
 {%- for node_name, node_grains in salt['mine.get']('ceph:mon:keyring:mon', 'grains.items', 'pillar').iteritems() %}
 
-{%- if node_grains.ceph is defined and node_grains.ceph.ceph_keyring is defined %}
+{%- if node_grains.ceph is defined and node_grains.ceph.ceph_keyring is defined and node_grains.ceph.get('fsid', '') == common.fsid %}
 
 {%- for name, keyring in node_grains.ceph.get("ceph_keyring", {}).iteritems() %}
 

--- a/ceph/init.sls
+++ b/ceph/init.sls
@@ -9,6 +9,9 @@ include:
 {% if pillar.ceph.mon is defined %}
 - ceph.mon
 {% endif %}
+{% if pillar.ceph.mgr is defined %}
+- ceph.mgr
+{% endif %}
 {% if pillar.ceph.osd is defined %}
 - ceph.osd
 {% endif %}

--- a/ceph/osd/setup.sls
+++ b/ceph/osd/setup.sls
@@ -31,7 +31,7 @@ ceph_osd_packages:
 zap_disk_{{ dev_device }}:
   cmd.run:
   - name: "ceph-disk zap {{ dev }}"
-  - unless: "ceph-disk list | grep {{ dev }} | grep ceph"
+  - unless: "ceph-disk list | grep {{ dev }} | grep -e 'ceph' -e 'mounted'"
   - require:
     - pkg: ceph_osd_packages
     - file: /etc/ceph/{{ common.get('cluster_name', 'ceph') }}.conf
@@ -44,7 +44,7 @@ zap_disk_{{ dev_device }}:
 zap_disk_journal_{{ disk.journal }}_for_{{ dev_device }}:
   cmd.run:
   - name: "ceph-disk zap {{ disk.journal }}"
-  - unless: "ceph-disk list | grep {{ disk.journal }} | grep ceph"
+  - unless: "ceph-disk list | grep {{ disk.journal }} | grep -e 'ceph' -e 'mounted'"
   - require:
     - pkg: ceph_osd_packages
     - file: /etc/ceph/{{ common.get('cluster_name', 'ceph') }}.conf
@@ -60,7 +60,7 @@ zap_disk_journal_{{ disk.journal }}_for_{{ dev_device }}:
 zap_disk_blockdb_{{ disk.block_db }}_for_{{ dev_device }}:
   cmd.run:
   - name: "ceph-disk zap {{ disk.block_db }}"
-  - unless: "ceph-disk list | grep {{ disk.block_db }} | grep ceph"
+  - unless: "ceph-disk list | grep {{ disk.block_db }} | grep -e 'ceph' -e 'mounted'"
   - require:
     - pkg: ceph_osd_packages
     - file: /etc/ceph/{{ common.get('cluster_name', 'ceph') }}.conf
@@ -76,7 +76,7 @@ zap_disk_blockdb_{{ disk.block_db }}_for_{{ dev_device }}:
 zap_disk_blockwal_{{ disk.block_wal }}_for_{{ dev_device }}:
   cmd.run:
   - name: "ceph-disk zap {{ disk.block_wal }}"
-  - unless: "ceph-disk list | grep {{ disk.block_wal }} | grep ceph"
+  - unless: "ceph-disk list | grep {{ disk.block_wal }} | grep -e 'ceph' -e 'mounted'"
   - require:
     - pkg: ceph_osd_packages
     - file: /etc/ceph/{{ common.get('cluster_name', 'ceph') }}.conf
@@ -164,7 +164,7 @@ zap_disk_blockwal_{{ disk.block_wal }}_for_{{ dev_device }}:
 prepare_disk_{{ dev_device }}:
   cmd.run:
   - name: "yes | ceph-disk prepare {{ cmd|join(' ') }}"
-  - unless: "ceph-disk list | grep {{ dev_device }} | grep ceph"
+  - unless: "ceph-disk list | grep {{ dev_device }} | grep -e 'ceph' -e 'mounted'"
   - require:
     - cmd: zap_disk_{{ dev_device }}
     - pkg: ceph_osd_packages
@@ -184,6 +184,8 @@ reload_partition_table_{{ dev_device }}:
     - file: /etc/ceph/{{ common.get('cluster_name', 'ceph') }}.conf
   {%- if grains.get('noservices') %}
   - onlyif: /bin/false
+  {%- else %}
+  - onlyif: ceph-disk list | grep {{ dev_device }} | grep ceph
   {%- endif %}
 
 activate_disk_{{ dev_device }}:
@@ -201,6 +203,8 @@ activate_disk_{{ dev_device }}:
     - file: /etc/ceph/{{ common.get('cluster_name', 'ceph') }}.conf
   {%- if grains.get('noservices') %}
   - onlyif: /bin/false
+  {%- else %}
+  - onlyif: ceph-disk list | grep {{ dev_device }} | grep ceph
   {%- endif %}
 
 {%- endif %}

--- a/ceph/setup/keyring.sls
+++ b/ceph/setup/keyring.sls
@@ -5,7 +5,7 @@
 {# run only if ceph cluster is present #}
 {%- for node_name, node_grains in salt['mine.get']('ceph:common:keyring:admin', 'grains.items', 'pillar').iteritems() %}
 
-{%- if node_grains.ceph is defined and node_grains.ceph.ceph_keyring is defined and node_grains.ceph.ceph_keyring.admin is defined %}
+{%- if node_grains.ceph is defined and node_grains.ceph.ceph_keyring is defined and node_grains.ceph.ceph_keyring.admin is defined and node_grains.ceph.get('fsid', '') == common.fsid %}
 
 {%- if loop.index0 == 0 %}
 

--- a/ceph/setup/pool.sls
+++ b/ceph/setup/pool.sls
@@ -26,7 +26,7 @@ ceph_pool_{{ pool_name }}_enable_{{ option_name }}:
   - name: ceph -c /etc/ceph/{{ common.get('cluster_name', 'ceph') }}.conf osd pool {{ option_name }} enable {{ pool_name }} {{ option_value }}
   - unless: "ceph -c /etc/ceph/{{ common.get('cluster_name', 'ceph') }}.conf osd pool {{ option_name }} get {{ pool_name }} | grep '{{ option_value }}'"
 
-{%- elif option_name not in ['type', 'pg_num', 'application', 'crush_rule'] %}
+{%- elif option_name not in ['type', 'pg_num', 'application', 'crush_rule', 'crush_ruleset_name', 'expected_num_objects'] %}
 
 ceph_pool_option_{{ pool_name }}_{{ option_name }}:
   cmd.run:

--- a/metadata/service/support.yml
+++ b/metadata/service/support.yml
@@ -6,7 +6,7 @@ parameters:
       heka:
         enabled: false
       sensu:
-        enabled: true
+        enabled: false
       sphinx:
         enabled: true
       telegraf:


### PR DESCRIPTION
in order to support multiple ceph clusters we added the fsid to the node grains, in order to be able to filter the correct admin keyring from salt mine.

Other fixes included:
* deployment of ceph.mon and ceph.mgr on same node (without the duplicate /etc/ceph/ceph.conf)
  * This configuration file is already handled by the ceph.common inclusion, so no need to define it again
* When creating pools, some options are defined in the pool pillar data, which are not compliant with ceph settings directly. For now i added those options in the blacklist.